### PR TITLE
Fixed what appears to be a typo in tutorial.

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -220,7 +220,7 @@ note that you can do multiple equations at once:
 also, if you want to use variables that are assigned in that exact same line, you must not use "%":
 
 	eq[] age=1, intel=age+1
-	:: Variable "age" will have the value of 2.
+	:: Variable "intel" will have the value of 2.
 
 A prettier alternative is `int[]`:
 


### PR DESCRIPTION
On one of the first eq[] mention, a variable
`age` was given the value 1 and a variable `intel`,
the value age+1 but the comment said the variable
`age` had the value 2. I fixed it so the comment
says the variable `intel` have the value 2.

- [ ] This PR add changes to the codebase.
- [x] This PR add changes to the documentations.
