### PR TITLE
Change "Hello, World." to "Hello, World!"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 
 ## What is FreakC ?
-`print[] Hello, World.`
+`print[] Hello, World!`
 
 FreakC is a nice, little, multi-paradigm programming language, which looks like Batch, compiles to Batch and is written in Batch as well. It is mainly built to be an experimental project with the idea of creating a programming language in such a limited language like Batch, but then it turns out that FreakC has added a little bit of features to Batch that might come in handy for some Batch developers. Batch's commands should work with FreakC most of the time, however, there are some quirks you should consider checking out which I have mentioned in the next part of this document.
 


### PR DESCRIPTION
On line 16 in `README.md`, "Hello, World!" is written as "Hello, World." (with a period) On line 25 however, it's written as "Hello, World!" (with an exclamation mark) -- which is widely recognized as the correct spelling (example: https://en.wikipedia.org/wiki/%22Hello,_World!%22_program). I, therefore, think that line 16 should be changed to say:
``print[] Hello, World!``

**Classification**
- [x] This PR adds changes to the documentations.